### PR TITLE
修复submail发送自定义内容重复拼接的问题

### DIFF
--- a/sms4j-provider/src/main/java/org/dromara/sms4j/submail/config/SubMailConfig.java
+++ b/sms4j-provider/src/main/java/org/dromara/sms4j/submail/config/SubMailConfig.java
@@ -36,13 +36,13 @@ public class SubMailConfig extends BaseConfig {
     /**
      * MD5 或 SHA-1 默认MD5 填写任意值，不为即为 密匙明文验证模式
      */
-    private String signType = "MD5";
+    private String signType = "md5";
 
     /**
      * signature加密计算方式
      * (当sign_version传2时，会忽略某些字段)
      */
-    private String signVersion;
+    private String signVersion = "2";
 
     /**
      * 获取供应商

--- a/sms4j-provider/src/main/java/org/dromara/sms4j/submail/service/SubMailSmsImpl.java
+++ b/sms4j-provider/src/main/java/org/dromara/sms4j/submail/service/SubMailSmsImpl.java
@@ -17,10 +17,7 @@ import org.dromara.sms4j.provider.service.AbstractSmsBlend;
 import org.dromara.sms4j.submail.config.SubMailConfig;
 import org.dromara.sms4j.submail.utils.SubMailUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Executor;
 
 /**
@@ -188,10 +185,9 @@ public class SubMailSmsImpl extends AbstractSmsBlend<SubMailConfig> {
         body.put("appid", config.getAccessKeyId());
         body.put("to", StrUtil.addPrefixIfNot(phone, "+86"));
         if (StrUtil.isNotBlank(config.getSignature())){
-            content = StrUtil.addPrefixIfNot(content, "【 " + config.getSignature() + "】") + StrUtil.sub(content, 0, 1000);
-        }else {
-            content = StrUtil.sub(content, 0, 1000);
+            content = StrUtil.addPrefixIfNot(content, "【 " + config.getSignature() + "】");
         }
+        content = StrUtil.sub(content, 0, 1000);
         body.put("content", content);
         body.put("timestamp", timestamp());
         body.put("sign_type", config.getSignType());
@@ -244,10 +240,9 @@ public class SubMailSmsImpl extends AbstractSmsBlend<SubMailConfig> {
         LinkedHashMap<String, Object> body = new LinkedHashMap<>();
         body.put("appid", config.getAccessKeyId());
         if (StrUtil.isNotBlank(config.getSignature())){
-            content = StrUtil.addPrefixIfNot(content, "【 " + config.getSignature() + "】") + StrUtil.sub(content, 0, 1000);
-        }else {
-            content = StrUtil.sub(content, 0, 1000);
+            content = StrUtil.addPrefixIfNot(content, "【 " + config.getSignature() + "】");
         }
+        content = StrUtil.sub(content, 0, 1000);
         body.put("content", content);
         phones = CollUtil.sub(phones, 0, 50);
         List<LinkedHashMap<String, Object>> multi = new ArrayList<>(phones.size());
@@ -316,10 +311,9 @@ public class SubMailSmsImpl extends AbstractSmsBlend<SubMailConfig> {
         phones = CollUtil.sub(phones, 0, 10000);
         body.put("to", SmsUtils.addCodePrefixIfNot(phones));
         if (StrUtil.isNotBlank(config.getSignature())){
-            content = StrUtil.addPrefixIfNot(content, "【 " + config.getSignature() + "】") + StrUtil.sub(content, 0, 1000);
-        }else {
-            content = StrUtil.sub(content, 0, 1000);
+            content = StrUtil.addPrefixIfNot(content, "【 " + config.getSignature() + "】");
         }
+        content = StrUtil.sub(content, 0, 1000);
         body.put("content", content);
         body.put("timestamp", timestamp());
         body.put("sign_type", config.getSignType());


### PR DESCRIPTION
- signType默认修改为小写的md5 // 大写MD5会导致签名失败，官方文档中描述：API 授权模式（ md5 or sha1 or normal ），
- signVersion默认修改为2 // 官方建议为2，避免参数中的特殊字符造成两边签名不一致。
- 修复submail发送自定义内容重复拼接的问题